### PR TITLE
feat(main): include basic auth header 

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,7 +104,11 @@ func main() {
 				})
 			}
 
-			resp, err := resty.New().R().SetHeader("Content-Type", "application/json").SetBody(jsonData).Post(*flagWebhook)
+			resp, err := resty.New().R().
+				SetHeader("Content-Type", "application/json").
+				SetBasicAuth(appContext.flags.AuthUSER, appContext.flags.AuthPASS).
+				SetBody(jsonData).
+				Post(*flagWebhook)
 			if err != nil {
 				log.Println(err)
 				return errors.New("E1: Cannot accept your message due to internal error, please report that to our engineers")


### PR DESCRIPTION
include a basic auth header using SMTP user and pass on the webhook request so it can be verified by the receiving webhook