### PR TITLE
Include flags on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ services:
     ]
 ```
 
+```text
+# .env Example
+WEBHOOK_URL=http://localhost:8080/api/smtp-hook
+SMTP_USER=user_for_this_smtp
+SMTP_PASSWORD=password_for_this_smtp
+```
+
 ## Native usage
 
 `smtp2http --listen=:25 --webhook=http://localhost:8080/api/smtp-hook`

--- a/main.go
+++ b/main.go
@@ -58,6 +58,10 @@ func main() {
 
 			// jsonData.Body.HTML = string(msg.HTMLBody)
 			jsonData.Body.HTML = getHTMLBody(appContext, msg)
+
+			jsonData.AppFlags.IsBase64 = appContext.flags.Base64HTML
+			jsonData.AppFlags.IsBase64Compressed = appContext.flags.CompressBase64
+
 			jsonData.Body.Text = string(msg.TextBody)
 
 			jsonData.Addresses.From = transformStdAddressToEmailAddress([]*mail.Address{c.From()})[0]

--- a/message.go
+++ b/message.go
@@ -53,6 +53,11 @@ type EmailMessage struct {
 
 	Attachments   []*EmailAttachment   `json:"attachments,omitempty"`
 	EmbeddedFiles []*EmailEmbeddedFile `json:"embedded_files,omitempty"`
+
+	AppFlags struct {
+		IsBase64           bool `json:"is_base64"`
+		IsBase64Compressed bool `json:"is_base64_compressed"`
+	} `json:"app_flags"`
 }
 
 type AppFlags struct {

--- a/start
+++ b/start
@@ -1,5 +1,7 @@
+source .env
+
 ./smtp2http -listen=0.0.0.0:25 \
     -webhook=${WEBHOOK_URL} \
     -user=${SMTP_USER} \
-    -pass=${SMTP_PASS} \
+    -pass=${SMTP_PASSWORD} \
     -base64html


### PR DESCRIPTION
This includes the following flags on the request body

- `is_base64` : (Boolean) a value of `true` indicates that html body is encoded in base64
- `is_base64_compressed`: (Boolean) a value of `true` indicates that the html body is gzip compressed and was encoded in base64

This allows the receiving webhook to determine the encoding of the html body