### PR TITLE
fix: include name in parsed From field for email payload

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net/mail"
 	"strings"
 	"time"
 
@@ -64,7 +63,8 @@ func main() {
 
 			jsonData.Body.Text = string(msg.TextBody)
 
-			jsonData.Addresses.From = transformStdAddressToEmailAddress([]*mail.Address{c.From()})[0]
+			// jsonData.Addresses.From = transformStdAddressToEmailAddress([]*mail.Address{c.From()})[0]
+			jsonData.Addresses.From = transformStdAddressToEmailAddress(msg.From)[0]
 			// jsonData.Addresses.To = transformStdAddressToEmailAddress([]*mail.Address{c.To()})[0]
 			jsonData.Addresses.To = transformStdAddressToEmailAddress(msg.To)
 


### PR DESCRIPTION
Updated the assignment of `jsonData.Addresses.From` to use `msg.From` instead of `c.From()`. This ensures that both the name and address are included in the parsed From field, resolving issue #5.